### PR TITLE
Hyperdrive LRU cache

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ import { createSecureServer } from 'http2'
 import process from 'process'
 import { readFileSync } from 'fs'
 import { promisify } from 'util'
-import { join } from 'path'
 import { GatewayHyperspace } from './services/gateway-hyperspace.js'
 import { HyperdriveController } from './infra/controllers/hyperdrive.js'
 import { ViewController } from './infra/controllers/view.js'
@@ -21,9 +20,11 @@ async function main () {
   await hyperspace.setup()
 
   const router = new Router([
-    new HyperdriveController(hyperspace.client),
+    new HyperdriveController({ client: hyperspace.client }),
     new ViewController(process.env.PUBLIC_ASSETS_DIRECTORY)
   ])
+
+  await router.initialize()
 
   const serverOptions = {
     key: readFileSync(process.env.SSL_KEY),

--- a/infra/controllers/view.js
+++ b/infra/controllers/view.js
@@ -1,6 +1,7 @@
 import { join, extname } from 'path'
 import { constants as http2Constants } from 'http2'
-import { access as fsAccess, constants as fsConstants } from 'fs'
+import { constants as fsConstants } from 'fs'
+import { access as fsAccess } from 'fs/promises'
 import mime from 'mime-types'
 
 const {
@@ -14,18 +15,12 @@ export class ViewController {
   constructor (staticDir) {
     this.staticDir = staticDir
     this.canServeStatic = false
-    this.initialize()
   }
 
-  initialize() {
+  async initialize () {
     if (!this.staticDir) return
-    fsAccess(this.staticDir, fsConstants.R_OK, err => {
-      if (err) {
-        console.error('ViewController not able to serve static assets', err)
-        process.exit(1)
-      }
-      this.canServeStatic = true
-    })
+    await fsAccess(this.staticDir, fsConstants.R_OK)
+    this.canServeStatic = true
   }
 
   handleRequest (stream, headers) {

--- a/infra/router.js
+++ b/infra/router.js
@@ -11,6 +11,13 @@ export class Router {
     this.handleRequest = this.handleRequest.bind(this)
   }
 
+  initialize () {
+    return Promise.all(this.controllers.map(async controller => {
+      if (typeof controller.initialize !== 'function') return
+      await controller.initialize()
+    }))
+  }
+
   async handleRequest (stream, headers) {
     try {
       let handled = false

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "hyperdrive": "^10.20.0",
         "hyperspace": "^3.19.0",
         "mime-types": "^2.1.30",
+        "quick-lru": "^6.0.0",
         "replacestream": "^4.0.3"
       },
       "devDependencies": {
@@ -4596,6 +4597,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.0.0.tgz",
+      "integrity": "sha512-kQ3ACYYIALMi7x8xvMU+qSF6N6baMZms8/q3dn2XFiORhFrLbpR6vTRNGR80HwlakWSoY4RnGoCJWUgnyH6zZQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/random-access-file": {
@@ -10003,6 +10015,11 @@
       "requires": {
         "escape-goat": "^2.0.0"
       }
+    },
+    "quick-lru": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.0.0.tgz",
+      "integrity": "sha512-kQ3ACYYIALMi7x8xvMU+qSF6N6baMZms8/q3dn2XFiORhFrLbpR6vTRNGR80HwlakWSoY4RnGoCJWUgnyH6zZQ=="
     },
     "random-access-file": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "hyperdrive": "^10.20.0",
     "hyperspace": "^3.19.0",
     "mime-types": "^2.1.30",
+    "quick-lru": "^6.0.0",
     "replacestream": "^4.0.3"
   },
   "devDependencies": {

--- a/test/infra/controllers/hyperdrive.spec.js
+++ b/test/infra/controllers/hyperdrive.spec.js
@@ -7,6 +7,7 @@ import { GatewayHyperspace } from '../../../services/gateway-hyperspace.js'
 import { HyperdriveController } from '../../../infra/controllers/hyperdrive.js'
 import { hexToBase32 } from '../../../lib/base32.js'
 import { buildDrive, mockConsoleLog, HYPERSPACE_OPTIONS } from '../../helpers.js'
+import { GatewayHyperdrive } from '../../../services/gateway-hyperdrive.js'
 
 const {
   HTTP2_HEADER_PATH,
@@ -32,7 +33,7 @@ describe('HyperdriveController', () => {
 
   beforeEach(() => {
     mockConsoleLog()
-    controller = new HyperdriveController(hyperspace.client)
+    controller = new HyperdriveController({ client: hyperspace.client })
   })
 
   describe('handleRequest', () => {
@@ -180,6 +181,13 @@ describe('HyperdriveController', () => {
         await controller.serveHyperdriveFile(stream, headers, driveBase32Key, 'test.com')
         assert.strictEqual(stream.respond.lastCall.args[0][':status'], HTTP_STATUS_NOT_FOUND)
       })
+    })
+  })
+
+  describe('cachedDrive', () => {
+    it('returns an instance of GatewayHyperdrive', () => {
+      const gatewayDrive = controller.cachedDrive(keyBase32)
+      assert(gatewayDrive instanceof GatewayHyperdrive)
     })
   })
 })

--- a/test/infra/controllers/view.spec.js
+++ b/test/infra/controllers/view.spec.js
@@ -4,6 +4,7 @@ import { constants as http2Constants } from 'http2'
 import simple from 'simple-mock'
 import mime from 'mime-types'
 import { extname } from 'path'
+import { tmpdir } from 'os'
 import { ViewController } from '../../../infra/controllers/view.js'
 import { mockConsoleLog } from '../../helpers.js'
 
@@ -16,11 +17,12 @@ const {
 
 describe('ViewController', () => {
   let controller
-  const publicDir = '/PUBLIC'
+  const publicDir = tmpdir()
 
-  beforeEach(() => {
+  beforeEach(async () => {
     mockConsoleLog()
     controller = new ViewController(publicDir)
+    await controller.initialize()
   })
 
   describe('handleRequest', () => {

--- a/test/infra/router.spec.js
+++ b/test/infra/router.spec.js
@@ -22,6 +22,14 @@ describe('Router', () => {
       router = new Router(controllers)
     })
 
+    describe('initialize', () => {
+      it('initializes each controller with an initialize method', async () => {
+        controllers[0].initialize = simple.stub()
+        await router.initialize()
+        assert(controllers[0].initialize.called)
+      })
+    })
+
     describe('request delegation', () => {
       it('attempts to delegate the request to each controller', async () => {
         controllers.forEach(x => x.handleRequest.resolveWith(false))

--- a/test/services/gateway-hyperdrive.spec.js
+++ b/test/services/gateway-hyperdrive.spec.js
@@ -1,11 +1,11 @@
 /* eslint-env mocha */
 import assert from 'assert'
-import { GatewayHyperdriveRead, HYPER_URL_PATTERN } from '../../services/gateway-hyperdrive-read.js'
+import { GatewayHyperdrive, HYPER_URL_PATTERN } from '../../services/gateway-hyperdrive.js'
 import { GatewayHyperspace } from '../../services/gateway-hyperspace.js'
 import rawBody from 'raw-body'
 import { buildDrive, mockConsoleLog, HYPERSPACE_OPTIONS } from '../helpers.js'
 
-describe('GatewayHyperdriveRead', () => {
+describe('GatewayHyperdrive', () => {
   const key = '34f4c3f0bcf6bf5c39d7814d373946d8f04da5b4a525d940c98309cafb111d93'
   let hyperspace
   let mainDrive
@@ -27,10 +27,10 @@ describe('GatewayHyperdriveRead', () => {
     await hyperspace.setup()
     moduleDrive = await buildDrive(hyperspace.client, '/index.js', jsContent)
     const moduleDriveKey = moduleDrive.key.toString('hex')
-    moduleDriveBase32Key = GatewayHyperdriveRead.toBase32(moduleDriveKey)
+    moduleDriveBase32Key = GatewayHyperdrive.toBase32(moduleDriveKey)
     mainDrive = await buildDrive(hyperspace.client, '/index.html', indexHtmlContent(moduleDriveKey))
     const mainDriveKey = mainDrive.key.toString('hex')
-    mainDriveBase32Key = GatewayHyperdriveRead.toBase32(mainDriveKey)
+    mainDriveBase32Key = GatewayHyperdrive.toBase32(mainDriveKey)
     await mainDrive.promises.writeFile('/logo.svg', svgContent)
   })
 
@@ -42,52 +42,48 @@ describe('GatewayHyperdriveRead', () => {
 
   describe('toBase32', () => {
     it('converts a hex key to base32', () => {
-      assert(GatewayHyperdriveRead.base32KeyIsValid(GatewayHyperdriveRead.toBase32(key)))
+      const base32Key = GatewayHyperdrive.toBase32(key)
+      assert(GatewayHyperdrive.base32KeyIsValid(base32Key))
     })
   })
 
   describe('base32KeyIsValid', () => {
     it('returns true for a valid base32 key', () => {
-      const base32Key = GatewayHyperdriveRead.toBase32(key)
-      assert.strictEqual(GatewayHyperdriveRead.base32KeyIsValid(base32Key), true)
+      const base32Key = GatewayHyperdrive.toBase32(key)
+      assert.strictEqual(GatewayHyperdrive.base32KeyIsValid(base32Key), true)
     })
 
     it('returns false for an invalid base32 key', () => {
-      const base32Key = GatewayHyperdriveRead.toBase32(key).slice(1)
-      assert.strictEqual(GatewayHyperdriveRead.base32KeyIsValid(base32Key), false)
+      const base32Key = GatewayHyperdrive.toBase32(key).slice(1)
+      assert.strictEqual(GatewayHyperdrive.base32KeyIsValid(base32Key), false)
     })
   })
 
   describe('resolveFile', () => {
     describe('file path exists', () => {
       it('returns the stat object', async () => {
-        const driveRead = new GatewayHyperdriveRead(hyperspace.client, moduleDriveBase32Key, '/index.js')
-        await driveRead.ready()
-        assert(true)
-        // const stat = await driveRead.resolveFile()
-        // assert(stat.size)
+        const gatewayDrive = new GatewayHyperdrive(hyperspace.client, moduleDriveBase32Key)
+        await gatewayDrive.ready()
+        const { stat } = await gatewayDrive.resolveFile('/index.js')
+        assert(stat.size)
       })
     })
 
     describe('file path does not exist', () => {
       describe('path has no extension', () => {
-        it('sets the name attribute to index.html', async () => {
-          const driveRead = new GatewayHyperdriveRead(hyperspace.client, mainDriveBase32Key, '/foo')
-          await driveRead.ready()
-          await driveRead.resolveFile()
-          assert.strictEqual(driveRead.name, '/index.html')
+        it('returns `index.html` as name', async () => {
+          const gatewayDrive = new GatewayHyperdrive(hyperspace.client, mainDriveBase32Key)
+          await gatewayDrive.ready()
+          const { name } = await gatewayDrive.resolveFile('/foo')
+          assert.strictEqual(name, '/index.html')
         })
 
         it('returns the stat of /index.html', async () => {
-          const driveRead1 = new GatewayHyperdriveRead(hyperspace.client, mainDriveBase32Key, '/foo')
-          const driveRead2 = new GatewayHyperdriveRead(hyperspace.client, mainDriveBase32Key, '/index.html')
-          await Promise.all([
-            driveRead1.ready(),
-            driveRead2.ready()
-          ])
-          const [stat1, stat2] = await Promise.all([
-            driveRead1.resolveFile(),
-            driveRead2.resolveFile()
+          const gatewayDrive = new GatewayHyperdrive(hyperspace.client, mainDriveBase32Key)
+          await gatewayDrive.ready()
+          const [{ stat: stat1 }, { stat: stat2 }] = await Promise.all([
+            gatewayDrive.resolveFile('/foo'),
+            gatewayDrive.resolveFile('/index.html')
           ])
           assert.strictEqual(stat1.size, stat2.size)
         })
@@ -95,9 +91,9 @@ describe('GatewayHyperdriveRead', () => {
 
       describe('path has extension', () => {
         it('throws an ENOENT error', async () => {
-          const driveRead = new GatewayHyperdriveRead(hyperspace.client, mainDriveBase32Key, '/foo.js')
-          await driveRead.ready()
-          return driveRead.resolveFile()
+          const gatewayDrive = new GatewayHyperdrive(hyperspace.client, mainDriveBase32Key)
+          await gatewayDrive.ready()
+          return gatewayDrive.resolveFile('/foo.js')
             .then(
               () => { throw new Error('Did not throw') },
               err => assert(err.code === 'ENOENT')
@@ -108,29 +104,34 @@ describe('GatewayHyperdriveRead', () => {
   })
 
   describe('createReadStream', () => {
+    it('updates lastReadTime', async () => {
+      const gatewayDrive = new GatewayHyperdrive(hyperspace.client, mainDriveBase32Key)
+      await rawBody(gatewayDrive.createReadStream('/logo.svg', 'https', 'test.com'), { encoding: 'utf-8' })
+      const { lastReadTime } = gatewayDrive
+      assert(typeof lastReadTime === 'number' && lastReadTime > 0)
+    })
+
     describe('file has web app file code extension (js, css, html)', () => {
       it('returns a stream for the hyperdrive file hyper links replaced with gateway links', async () => {
         const scheme = 'https'
         const host = 'test.com'
-        const driveRead = new GatewayHyperdriveRead(hyperspace.client, moduleDriveBase32Key, '/index.js')
-        const driveReadData = await rawBody(driveRead.createReadStream(scheme, host), { encoding: 'utf-8' })
+        const gatewayDrive = new GatewayHyperdrive(hyperspace.client, moduleDriveBase32Key)
+        const gatewayDriveData = await rawBody(gatewayDrive.createReadStream('/index.js', scheme, host), { encoding: 'utf-8' })
         const driveData = await rawBody(moduleDrive.promises.createReadStream('/index.js'), { encoding: 'utf-8' })
         const dataTransformed = driveData.replace(
           new RegExp(HYPER_URL_PATTERN, 'gi'),
-          (_, preceedingChar, key) => `${preceedingChar}${scheme}://${this.toBase32(key)}.${host}`
+          (_, preceedingChar, key) => `${preceedingChar}${scheme}://${GatewayHyperdrive.toBase32(key)}.${host}`
         )
-        assert.strictEqual(driveReadData, dataTransformed)
+        assert.strictEqual(gatewayDriveData, dataTransformed)
       })
     })
 
     describe('file does not have web app code extension', () => {
       it('returns a read stream for the hyperdrive file', async () => {
-        const scheme = 'https'
-        const host = 'test.com'
-        const driveRead = new GatewayHyperdriveRead(hyperspace.client, mainDriveBase32Key, '/logo.svg')
-        const driveReadData = await rawBody(driveRead.createReadStream(scheme, host), { encoding: 'utf-8' })
+        const gatewayDrive = new GatewayHyperdrive(hyperspace.client, mainDriveBase32Key)
+        const gatewayDriveData = await rawBody(gatewayDrive.createReadStream('/logo.svg', 'https', 'test.com'), { encoding: 'utf-8' })
         const driveData = await rawBody(mainDrive.promises.createReadStream('/logo.svg'), { encoding: 'utf-8' })
-        assert.strictEqual(driveReadData, driveData)
+        assert.strictEqual(gatewayDriveData, driveData)
       })
     })
   })


### PR DESCRIPTION
- Use a least-recently-used cache for the hyperdrives created by the gateway.
- Rename `GatewayHyperdriveRead` to `GatewayHyperdrive`.  Don't accept file path in constructor.  Instead pass it in to the methods that need it.
- Have the router initialize the controllers.  Expose an initialize method on the router.